### PR TITLE
Prevent infinite recursion on empty template

### DIFF
--- a/src/plumes-component.js
+++ b/src/plumes-component.js
@@ -22,7 +22,7 @@
         _this = this,
         _name = null,
         _collection = null,
-        _template = '',
+        _template = null,
         _templateSrc = null,
         _controllers = null,
         _converters = {},
@@ -245,7 +245,7 @@
     }
 
     this.compile = function(callback) {
-      if(!_template) {
+      if(_template === null) {
         _templateSrc = _templateSrc ? _templateSrc : $component.attr('pl-component-src');
         var theme = plumes.theme();
         if(theme) {


### PR DESCRIPTION
When using `pl-page="page1" src="empty-page.html"`, if the content of the page is empty then we will get an infinite recursion on the template loading